### PR TITLE
Restructured Code to go through each build file possible

### DIFF
--- a/auto-builder/auto-compiler.sh
+++ b/auto-builder/auto-compiler.sh
@@ -48,56 +48,54 @@ while read -r repo; do
     # Check for build exec or just build
     cd "$dirName" 
     iteration=$((iteration+1))
-    if [ -f "gradlew" ];
+    MAVEN_BUILDFILE="pom.xml"
+    GRADLE_BUILDFILE="build.gradle"
+    ANT_BUILDFILE="build.xml"
+    
+
+    check_build () {
+        find -name $1 > .build_files.txt ; BUILDFILES=".build_files.txt"
+        FILECOUNT=$(wc -l $BUILDFILES | sed 's/\s.*$//')
+        return $FILECOUNT
+    }
+    
+    if check_build MAVEN_BUILDFILE -gt 0 
     then
-        echo "[Gradlew file Exists]"
-        gradlew_output=$(./gradlew compileJava </dev/null 2>"$outdir"/"$dirName".log ); gradlew_return_code=$? 
-        if [ $gradlew_return_code != 0 ] 
-        then 
-            failed=$((failed+1))
-        else 
-            echo "$repo" >> $buildable
-            successful=$((successful+1))
-        fi
-        cd "$outdir"
-        rm -rf "$dirName"
-        continue 
-    elif [ -f "pom.xml" ];
-    then
-        echo "[Pom.xml file Exists]"
-        maven_output=$(mvn compile); maven_return_code=$?
-        if [ $maven_return_code != 0 ] 
-        then 
-            failed=$((failed+1))
-            cd "$outdir"
-        else
-            echo "$repo" >> $buildable
-            successful=$((successful+1))    
-        fi
-        cd "$outdir" | exit 1
-        rm -rf "$dirName"
-        continue
-    elif [ -f "build.xml" ];
-    then
-        echo "[Build.xml file Exists]"
-        maven_output=$(ant compile); ant_return_code=$?
-        if [ $ant_return_code != 0 ] 
-        then 
-            failed=$((failed+1))
-        else 
-            echo "$repo" >> $buildable
-            successful=$((successful+1))
-        fi
-        cd "$outdir"
-        rm -rf "$dirName"
-        continue
-    else
-        cd "$outdir"
-        rm -rf "$dirName" && echo "[Deleted $dirName]"
-        missingBuildFile=$((missingBuildFile+1))
-    fi
-    echo "[Progress:$iteration/$linksCount successful:$successful failed:$failed]"
-    #exit 0 # This is for testing a single project at a time. Remove this to use entire file.   
+        echo "This is a maven build"
+        # Lets starting looping through the list of build files we found
+        while read -r BUILDFILE; do
+            # Here we are checking for each build file to see if it is using checkerframework 
+            CHECK=$(rg "org.checkerframework" $BUILDFILE)
+            # If check exists for our string query, lets work with it, otherwise, continue to the next file 
+            if [ -z $CHECK ]
+            then 
+                cd # cd to the path of the file 
+                GRADLEW="gradlew"#somtimes, gradlew does not have permissions 
+                if [ -z $GRADLEW ]
+                then 
+                    chmod +x $gradlew # somtimes the build files do not have privleges to be executed
+                    # We assume at this point we that, there is a gradlew exec. Need to handle somehow
+                    gradlew_output=$(./gradlew compileJava </dev/null 2>"$outdir"/"$dirName".log ); gradlew_return_code=$? 
+                    if [ $gradlew_return_code != 0 ] 
+                    then 
+                        failed=$((failed+1))
+                    else 
+                        echo "$repo" >> $buildable
+                        successful=$((successful+1))
+                    fi
+                else
+                    # What should we do if a gradlew exec does not exist? Move onto the next pom.xml I suppose. 
+                fi
+            else 
+                continue # Lets move onto the next build file in the list
+            fi
+            # cd to the path of that build file 
+            # attempt to build in that specific directory
+        done < $BUILDFILES
+    else 
+        rm $BUILDFILES
+    fi  
+    exit 0   
 done < "$file"
 rm -r $outdir
 echo "[Progress:$iteration/$linksCount successful:$successful failed:$failed Missing Build:$missingBuildFile]"


### PR DESCRIPTION
I am modifying the script to consider every potential build file in the project, the basic logic is described here. 

1. Loop through a list of projects, clone each one and cd into the clone 
2. Check for a build file type using find, output results to a txt file 
3. If more than 0 build files exist of a type, lets operate on them
4. Check each build file for the use of the checker-framework, if present, attempt to change to the location  of that build file and 
attempt to build 
6. If the build fails continue through the list of build files, if successful, add the repo to the list
7. If no successful build, continue onto the next link

The code itself is int shambles but I will fix it up once I have a working solution.